### PR TITLE
대화방 정보 조회시 거래 여부(isSelected) 반환(#62)

### DIFF
--- a/src/main/java/com/prgrms/offer/domain/message/model/dto/MessageRoomInfoResponse.java
+++ b/src/main/java/com/prgrms/offer/domain/message/model/dto/MessageRoomInfoResponse.java
@@ -5,6 +5,7 @@ import com.prgrms.offer.domain.article.model.entity.Article;
 import com.prgrms.offer.domain.member.model.entity.Member;
 import com.prgrms.offer.domain.offer.model.entity.Offer;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
@@ -13,6 +14,7 @@ public class MessageRoomInfoResponse  {
 
     private ArticleInfo articleInfo;
     private MessagePartnerInfo messagePartnerInfo;
+    private OfferInfo offerInfo;
     private long lastPageOfMessageContents;
 
     @AllArgsConstructor
@@ -21,14 +23,12 @@ public class MessageRoomInfoResponse  {
 
         private String title;
         private int price;
-        private int offerPrice;
         private String productImageUrl;
 
-        public static MessageRoomInfoResponse.ArticleInfo createArticleInfo(Article article, Offer offer) {
+        public static MessageRoomInfoResponse.ArticleInfo createArticleInfo(Article article) {
             return new MessageRoomInfoResponse.ArticleInfo(
                 article.getTitle(),
                 article.getPrice(),
-                offer.getPrice(),
                 article.getMainImageUrl()
             );
         }
@@ -50,6 +50,25 @@ public class MessageRoomInfoResponse  {
             Member member) {
             return new MessageRoomInfoResponse.MessagePartnerInfo(member.getNickname(),
                 member.getProfileImageUrl());
+        }
+    }
+
+    @EqualsAndHashCode
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    public static class OfferInfo {
+
+        private int offerPrice;
+        private boolean isSelected;
+
+        public OfferInfo(int offerPrice, boolean isSelected) {
+            this.offerPrice = offerPrice;
+            this.isSelected = isSelected;
+        }
+
+        public static MessageRoomInfoResponse.OfferInfo createOfferInfo(
+                Offer offer) {
+            return new MessageRoomInfoResponse.OfferInfo(offer.getPrice(),
+                    offer.getIsSelected());
         }
     }
 

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageConverter.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageConverter.java
@@ -46,8 +46,9 @@ public class MessageConverter {
     public MessageRoomInfoResponse toMessageRoomInfoResponse(Member messagePartner, Article article,
         Offer offer, long lastPageOfMessageContents) {
         return new MessageRoomInfoResponse(
-            MessageRoomInfoResponse.ArticleInfo.createArticleInfo(article, offer),
+            MessageRoomInfoResponse.ArticleInfo.createArticleInfo(article),
             MessageRoomInfoResponse.MessagePartnerInfo.createMessagePartnerInfo(messagePartner),
+            MessageRoomInfoResponse.OfferInfo.createOfferInfo(offer),
             lastPageOfMessageContents
         );
     }

--- a/src/test/java/com/prgrms/offer/domain/message/service/MessageServiceTest.java
+++ b/src/test/java/com/prgrms/offer/domain/message/service/MessageServiceTest.java
@@ -4,12 +4,14 @@ import com.prgrms.offer.domain.article.model.entity.Article;
 import com.prgrms.offer.domain.article.repository.ArticleRepository;
 import com.prgrms.offer.domain.member.model.entity.Member;
 import com.prgrms.offer.domain.member.repository.MemberRepository;
+import com.prgrms.offer.domain.message.model.dto.MessageRoomInfoResponse;
 import com.prgrms.offer.domain.message.model.entity.MessageRoom;
 import com.prgrms.offer.domain.message.repository.MessageRepository;
 import com.prgrms.offer.domain.message.repository.MessageRoomRepository;
 import com.prgrms.offer.domain.offer.model.entity.Offer;
 import com.prgrms.offer.domain.offer.repository.OfferRepository;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,6 +125,25 @@ class MessageServiceTest {
         assertThat(offererMessageRoom.getMember()).isEqualTo(partner);
         assertThat(myMessageRoom.getMember()).isEqualTo(me);
 
+    }
+
+
+    @DisplayName("대화방 정보 조회하기")
+    @Test
+    void getMessageRoomInfo() {
+
+        messageService.sendMessageToOffererOnclickMessageButton(
+                me.getId(), partner.getId(), offer.getId(), "판매자에게 거래 제안 메시지를 전송한다.");
+
+        MessageRoom myMessageRoom = messageRoomRepository.findByMemberAndPartnerAndOffer(
+                me, partner, offer).orElse(messageService.createMessageRoom(me, partner, offer)
+        );
+
+        MessageRoomInfoResponse messageRoomInfoResponse = messageService.getMessageRoomInfo(myMessageRoom.getId(), me.getId());
+
+        MessageRoomInfoResponse.OfferInfo offerInfo = MessageRoomInfoResponse.OfferInfo.createOfferInfo(offer);
+
+        assertThat(messageRoomInfoResponse.getOfferInfo()).isEqualTo(offerInfo);
     }
 
 


### PR DESCRIPTION
resolve #62

### 내용
- 대화방 정보(MessageRoomInfoResponse Dto)에서 거래 여부(isSelected) 필드 추가
- MessageRoomInfoResponse에서 offer 관련 정보(offerPrice, isSelected)를 별도 필드(offerInfo)로 분리

